### PR TITLE
Minor figcaption fixes

### DIFF
--- a/packages/volto-iframe-block/locales/de/LC_MESSAGES/volto.po
+++ b/packages/volto-iframe-block/locales/de/LC_MESSAGES/volto.po
@@ -13,6 +13,7 @@ msgstr ""
 
 #. Default: "Credit"
 #: components/schema
+#: components/View
 msgid "Credit"
 msgstr "Credit"
 

--- a/packages/volto-iframe-block/locales/de/LC_MESSAGES/volto.po
+++ b/packages/volto-iframe-block/locales/de/LC_MESSAGES/volto.po
@@ -63,10 +63,10 @@ msgstr "Seitenverhältnis beibehalten"
 msgid "Preserve aspect ratio based on initial width and height"
 msgstr "Seitenverhältnis basierend auf der ursprünglichen Breite und Höhe beibehalten"
 
-#. Default: "Provide an iFrame title for better accessibility for screenreaders (title will not be visible),"
+#. Default: "Provide an iFrame title for better accessibility,"
 #: components/schema
-msgid "Provide an iFrame title for better accessibility for screenreaders (title will not be visible),"
-msgstr "Geben Sie einen iFrame-Titel an, um die Zugänglichkeit für Screenreader zu verbessern (der Titel wird nicht angezeigt),"
+msgid "Provide an iFrame title for better accessibility,"
+msgstr "Geben Sie einen iFrame-Titel an, um die Barrierefreiheit zu verbessern,"
 
 #. Default: "Source"
 #: components/schema
@@ -86,12 +86,12 @@ msgstr "Geben Sie eine URL ein"
 #. Default: "Values are in Pixels (e.g. 100 or 100px) or Percent (e.g. 100%)"
 #: components/schema
 msgid "Values are in Pixels (e.g. 100 or 100px) or Percent (e.g. 100%)"
-msgstr "Die Werte werden in Pixeln (z.B. 100 oder 100px) oder Prozent (z.B. 100%) angegeben."
+msgstr "Werte können in Pixeln (z.B. "100" oder "100px") oder in Prozent (z.B. "100%") angegeben werden."
 
 #. Default: "Width"
 #: components/schema
 msgid "Width"
-msgstr "Weite"
+msgstr "Breite"
 
 #. Default: "see WCAG 2.1"
 #: components/schema

--- a/packages/volto-iframe-block/locales/en/LC_MESSAGES/volto.po
+++ b/packages/volto-iframe-block/locales/en/LC_MESSAGES/volto.po
@@ -13,6 +13,7 @@ msgstr ""
 
 #. Default: "Credit"
 #: components/schema
+#: components/View
 msgid "Credit"
 msgstr ""
 
@@ -64,9 +65,9 @@ msgstr ""
 msgid "Preserve aspect ratio based on initial width and height"
 msgstr ""
 
-#. Default: "Provide an iFrame title for better accessibility for screenreaders (title will not be visible),"
+#. Default: "Provide an iFrame title for better accessibility,"
 #: components/schema
-msgid "Provide an iFrame title for better accessibility for screenreaders (title will not be visible),"
+msgid "Provide an iFrame title for better accessibility,"
 msgstr ""
 
 #. Default: "Source"

--- a/packages/volto-iframe-block/locales/es/LC_MESSAGES/volto.po
+++ b/packages/volto-iframe-block/locales/es/LC_MESSAGES/volto.po
@@ -20,6 +20,7 @@ msgstr ""
 
 #. Default: "Credit"
 #: components/schema
+#: components/View
 msgid "Credit"
 msgstr ""
 
@@ -71,9 +72,9 @@ msgstr ""
 msgid "Preserve aspect ratio based on initial width and height"
 msgstr ""
 
-#. Default: "Provide an iFrame title for better accessibility for screenreaders (title will not be visible),"
+#. Default: "Provide an iFrame title for better accessibility,"
 #: components/schema
-msgid "Provide an iFrame title for better accessibility for screenreaders (title will not be visible),"
+msgid "Provide an iFrame title for better accessibility,"
 msgstr ""
 
 #. Default: "Source"

--- a/packages/volto-iframe-block/locales/pt_BR/LC_MESSAGES/volto.po
+++ b/packages/volto-iframe-block/locales/pt_BR/LC_MESSAGES/volto.po
@@ -18,6 +18,7 @@ msgstr ""
 
 #. Default: "Credit"
 #: components/schema
+#: components/View
 msgid "Credit"
 msgstr ""
 
@@ -69,9 +70,9 @@ msgstr ""
 msgid "Preserve aspect ratio based on initial width and height"
 msgstr ""
 
-#. Default: "Provide an iFrame title for better accessibility for screenreaders (title will not be visible),"
+#. Default: "Provide an iFrame title for better accessibility,"
 #: components/schema
-msgid "Provide an iFrame title for better accessibility for screenreaders (title will not be visible),"
+msgid "Provide an iFrame title for better accessibility,"
 msgstr ""
 
 #. Default: "Source"

--- a/packages/volto-iframe-block/locales/volto.pot
+++ b/packages/volto-iframe-block/locales/volto.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Plone\n"
-"POT-Creation-Date: 2025-09-18T22:04:20.013Z\n"
+"POT-Creation-Date: 2025-09-19T18:51:21.348Z\n"
 "Last-Translator: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "Language-Team: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "Content-Type: text/plain; charset=utf-8\n"
@@ -15,6 +15,7 @@ msgstr ""
 
 #. Default: "Credit"
 #: components/schema
+#: components/View
 msgid "Credit"
 msgstr ""
 
@@ -66,9 +67,9 @@ msgstr ""
 msgid "Preserve aspect ratio based on initial width and height"
 msgstr ""
 
-#. Default: "Provide an iFrame title for better accessibility for screenreaders (title will not be visible),"
+#. Default: "Provide an iFrame title for better accessibility,"
 #: components/schema
-msgid "Provide an iFrame title for better accessibility for screenreaders (title will not be visible),"
+msgid "Provide an iFrame title for better accessibility,"
 msgstr ""
 
 #. Default: "Source"

--- a/packages/volto-iframe-block/news/+minorFigcaptionFixes.bugfix
+++ b/packages/volto-iframe-block/news/+minorFigcaptionFixes.bugfix
@@ -1,0 +1,1 @@
+Minor style and messages fixes for Iframe figcaption. @danalvrz 

--- a/packages/volto-iframe-block/src/components/View.jsx
+++ b/packages/volto-iframe-block/src/components/View.jsx
@@ -44,14 +44,18 @@ const IframeView = (props) => {
               )}
               {data.credit && (
                 <div className="credit">
-                  Credit:{' '}
+                  <FormattedMessage id="Credit" defaultMessage="Credit" />:
                   <div dangerouslySetInnerHTML={{ __html: data.credit.data }} />
                 </div>
               )}
             </figcaption>
           </figure>
         ) : (
-          isEditMode && <div className="invalid-url message"><FormattedMessage id="Invalid URL" defaultMessage="Invalid URL" /></div>
+          isEditMode && (
+            <div className="invalid-url message">
+              <FormattedMessage id="Invalid URL" defaultMessage="Invalid URL" />
+            </div>
+          )
         )}
       </div>
     </div>

--- a/packages/volto-iframe-block/src/components/schema.jsx
+++ b/packages/volto-iframe-block/src/components/schema.jsx
@@ -30,9 +30,8 @@ const messages = defineMessages({
     defaultMessage: 'Height',
   },
   TitleTextHint: {
-    id: 'Provide an iFrame title for better accessibility for screenreaders (title will not be visible),',
-    defaultMessage:
-      'Provide an iFrame title for better accessibility for screenreaders (title will not be visible),',
+    id: 'Provide an iFrame title for better accessibility,',
+    defaultMessage: 'Provide an iFrame title for better accessibility,',
   },
   TitleLinkTextHint: {
     id: 'see WCAG 2.1',

--- a/packages/volto-iframe-block/src/theme/main.scss
+++ b/packages/volto-iframe-block/src/theme/main.scss
@@ -32,18 +32,30 @@
   }
 
   .invalid-url {
-  padding: 1.5em;
-  background: #f9edbe;
-  text-align: center;
+    padding: 1.5em;
+    background: #f9edbe;
+    text-align: center;
   }
-
-
 }
 
 .block.iframe {
   figure {
     margin-right: auto;
     margin-left: auto;
+
+    figcaption {
+      .credit {
+        margin-top: 10px;
+        display: flex;
+        align-items: center;
+        & > div {
+          margin-left: 4px;
+          * {
+            font-size: inherit;
+          }
+        }
+      }
+    }
   }
   iframe {
     width: 100%;

--- a/packages/volto-iframe-block/src/theme/main.scss
+++ b/packages/volto-iframe-block/src/theme/main.scss
@@ -45,9 +45,9 @@
 
     figcaption {
       .credit {
-        margin-top: 10px;
         display: flex;
         align-items: center;
+        margin-top: 10px;
         & > div {
           margin-left: 4px;
           * {


### PR DESCRIPTION
Before:

<img width="1024" height="390" alt="Screenshot 2025-09-19 at 1 29 52 p m" src="https://github.com/user-attachments/assets/9f762940-32d4-462f-8b22-8ed5a40625dc" />

After:

<img width="1021" height="380" alt="Screenshot 2025-09-19 at 2 18 43 p m" src="https://github.com/user-attachments/assets/619e7dd7-3119-4026-990d-c6ed0518769e" />

